### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "name": "Import PDF as Images",
     "type": "app",
+    "instance_version": "6.15.60",
     "categories": [
         "import",
         "images"

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
         "images"
     ],
     "description": "Drag and drop PDFs to import pages as images to Supervisely",
-    "docker_image": "supervisely/base-py-sdk:6.72.81",
+    "docker_image": "supervisely/base-py-sdk:6.73.564",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
